### PR TITLE
cleaning up stuff

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,23 +2,36 @@ FROM ubuntu:21.04
 
 # Make sure that the underlying container is patched to the latest versions
 RUN apt update && \
-    apt install -y wget tar gzip
-
-RUN useradd -d /home/focalboard -m -s /bin/bash focalboard && \
-    echo "focalboard:focalboard" | chpasswd && adduser focalboard sudo
+    apt install -y wget tar gzip && \
+    rm -rf /var/lib/apt/lists/*
 
 # Now install Focalboard as a seperate layer
 RUN wget https://github.com/mattermost/focalboard/releases/download/v0.6.1/focalboard-server-linux-amd64.tar.gz && \
     tar -xvzf focalboard-server-linux-amd64.tar.gz && \
     mv focalboard /opt
 
+# multi-stage build
+FROM ubuntu:21.04
+
+# update system
+RUN apt update && \
+    apt install -y nginx && \
+    rm -rf /var/lib/apt/lists/*
+
+# configure nginx
+COPY nginx-site /etc/nginx/sites-enabled/focalboard
+
+# add non root user
+RUN useradd -d /home/focalboard -m -s /bin/bash focalboard && \
+    echo "focalboard:focalboard" | chpasswd && adduser focalboard sudo
+
+# gert interesting stuff from builder image
+WORKDIR /opt/focalboard
+COPY --from=0 /opt/focalboard .
+
 RUN chown -R focalboard:focalboard /opt/focalboard
 
 EXPOSE 8000
 
 USER focalboard
-WORKDIR /opt/focalboard
-
-
-
-
+##CMD [ "/opt/focalboard/bin/focalboard-server" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,14 +9,17 @@ services:
       interval: 10s
       retries: 10
     restart: always
+    ports:
+      - 5432:5432
     environment:
-      - POSTGRES_USER_FILE=/run/secrets/focalboard-db
-      - POSTGRES_PASSWORD_FILE=/run/secrets/focalboard-db
-      - POSTGRES_DB_FILE=/run/secrets/focalboard-db
+      - POSTGRES_USER_FILE=/run/secrets/db_user
+      - POSTGRES_PASSWORD_FILE=/run/secrets/db_passwd
+      - POSTGRES_DB=boards
     volumes:
-    - "/opt/postgresql/focalboard/data:/var/lib/postgresql/data"
+      - "/opt/postgresql/focalboard/data:/var/lib/postgresql/data"
     secrets:
-      - focalboard-db
+      - db_user
+      - db_passwd
 
   focalboard:
     build: 
@@ -33,7 +36,9 @@ services:
     command: /opt/focalboard/bin/focalboard-server
     volumes:
       - "./config.json:/opt/focalboard/config.json"
-secrets:
-  focalboard-db:
-    file: "./focalboard-db.txt"
 
+secrets:
+  db_user:
+    file: ./focal_db_user.txt
+  db_passwd:
+    file: ./focal_db_passwd.txt

--- a/focal_db_passwd.txt
+++ b/focal_db_passwd.txt
@@ -1,0 +1,1 @@
+boardsuser-password

--- a/focal_db_user.txt
+++ b/focal_db_user.txt
@@ -1,0 +1,1 @@
+boardsuser

--- a/focalboard-db.txt
+++ b/focalboard-db.txt
@@ -1,3 +1,0 @@
-POSTGRES_USER=boardsuser
-POSTGRES_PASSWORD=boardsuser-password
-POSTGRES_DB=boards

--- a/nginx-site
+++ b/nginx-site
@@ -1,0 +1,49 @@
+upstream focalboard {
+   server localhost:8000;
+   keepalive 32;
+}
+
+server {
+   listen 80 default_server;
+
+   server_name localhost;
+
+   location ~ /ws/* {
+       proxy_set_header Upgrade $http_upgrade;
+       proxy_set_header Connection "upgrade";
+       client_max_body_size 50M;
+       proxy_set_header Host $http_host;
+       proxy_set_header X-Real-IP $remote_addr;
+       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+       proxy_set_header X-Forwarded-Proto $scheme;
+       proxy_set_header X-Frame-Options SAMEORIGIN;
+       proxy_buffers 256 16k;
+       proxy_buffer_size 16k;
+       client_body_timeout 60;
+       send_timeout 300;
+       lingering_timeout 5;
+       proxy_connect_timeout 1d;
+       proxy_send_timeout 1d;
+       proxy_read_timeout 1d;
+       proxy_pass http://focalboard;
+   }
+
+   location / {
+       client_max_body_size 50M;
+       proxy_set_header Connection "";
+       proxy_set_header Host $http_host;
+       proxy_set_header X-Real-IP $remote_addr;
+       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+       proxy_set_header X-Forwarded-Proto $scheme;
+       proxy_set_header X-Frame-Options SAMEORIGIN;
+       proxy_buffers 256 16k;
+       proxy_buffer_size 16k;
+       proxy_read_timeout 600s;
+       proxy_cache_revalidate on;
+       proxy_cache_min_uses 2;
+       proxy_cache_use_stale timeout;
+       proxy_cache_lock on;
+       proxy_http_version 1.1;
+       proxy_pass http://focalboard;
+   }
+}


### PR DESCRIPTION
Hi Davorin,
I stumbled on your LinkedIn post about this repo. Fund it interesting and poked around a bit, but I couldn't make it work. So I read the focalboard docs and realized nginx was missing. Since you run an Ubuntu, I installed nginx directly there. Ideally, we should run a separate container for nginx, and keep the focalboard app behind the scene. Ideally again, it should run on an Alpine container, for size and attack surface minimization. I didn't test if that would work yet, it should since there is no dependency listed in the focalboard docs for Ubuntu per se...
Anyway, made it a clean multi-stage build to stick to best practices, and I fixed a couple of issues I had with the DB. The first time you build, you need to docker-compose up --build -d. The focal app will fail (exit 1), but after the DB is up and running (first time needs DB creation, it takes some cycles) then simply docker-compose restart <focalapp>. Subsequent starts, don't --build and it works fine.
Alex.